### PR TITLE
Rename NewMatrix to just New

### DIFF
--- a/oo/constructors.md
+++ b/oo/constructors.md
@@ -3,7 +3,7 @@ Go doesn't support constructors, but constructor-like factory functions are easy
 
 ```go
 package matrix
-function NewMatrix(rows, cols int) *matrix {
+function New(rows, cols int) *matrix {
     m := new(matrix)
     m.rows = rows
     m.cols = cols
@@ -17,7 +17,7 @@ To prevent users from instantiating uninitialized objects, the struct can be mad
 package main
 import "matrix"
 wrong := new(matrix.matrix)    // will NOT compile (matrix is private)
-right := matrix.NewMatrix(2,3) // ONLY way to instantiate a matrix
+right := matrix.New(2,3) // ONLY way to instantiate a matrix
 
 ```
 ## Initializers
@@ -25,7 +25,7 @@ right := matrix.NewMatrix(2,3) // ONLY way to instantiate a matrix
 Go aims to prevent unnecessary typing.  Oftentimes Go code is shorter and easier to read than object-oriented languages.  Compare the use of factory functions and initializers in Go to the use of constructors in Java:
 
 ```go
-matrix := NewMatrix(10, 10)
+matrix := New(10, 10)
 pair := &Pair{"one", 1}
 ```
 ```java
@@ -36,7 +36,7 @@ Pair pair = new Pair ("one", 1);
 Additionally, Go "constructors" can be written succinctly using initializers within a factory function:
 
 ```go
-function NewMatrix(rows, cols, int) *matrix {
+function New(rows, cols, int) *matrix {
     return &matrix{rows, cols, make([]float, rows*cols)}
 }
 ```


### PR DESCRIPTION
Using the name `NewMatrix` in the package `matrix` is not idiomatic:

> Similarly, the function to make new instances of ring.Ring—which is the definition of a constructor in Go—would normally be called NewRing, but since Ring is the only type exported by the package, and since the package is called ring, it's called just New, which clients of the package see as ring.New. Use the package structure to help you choose good names.

https://golang.org/doc/effective_go.html#package-names