### PR TITLE
Fixed typo

### DIFF
--- a/oo/constructors.md
+++ b/oo/constructors.md
@@ -36,7 +36,7 @@ Pair pair = new Pair ("one", 1);
 Additionally, Go "constructors" can be written succinctly using initializers within a factory function:
 
 ```go
-function New(rows, cols, int) *matrix {
+func New(rows, cols, int) *matrix {
     return &matrix{rows, cols, make([]float, rows*cols)}
 }
 ```


### PR DESCRIPTION
Go uses `func` instead of `function`