### PR TITLE
closing channel when iterator is done

### DIFF
--- a/oo/iterators.md
+++ b/oo/iterators.md
@@ -29,6 +29,7 @@ func (c *container) Iter () <-chan item {
         for i := 0; i < c.size; i++ {
             ch <- c.items[i]
         }
+		close(ch)
     } ();
     return ch
 }


### PR DESCRIPTION
The code didn't close the channel.
This will lead to the following problem-
`fatal error: all goroutines are asleep - deadlock!`
