### PR TITLE
Update parallel-for-loop.md

### DIFF
--- a/concurrency/parallel-for-loop.md
+++ b/concurrency/parallel-for-loop.md
@@ -9,33 +9,35 @@ Some languages provide a parallel for-loop (e.g. Sun's Fortress) which can simpl
 ```go
 type empty {}
 ...
-data := make([]float, N);
-res := make([]float, N);
-sem := make(chan empty, N);  // semaphore pattern
+data := make([]float32, N)
+res := make([]float32, N)
+var wg sync.WaitGroup
 ...
 for i,xi := range data {
-    go func (i int, xi float) {
-        res[i] = doSomething(i,xi);
-        sem <- empty{};
+    wd.add(1)
+    go func (i int, xi float32) {
+        defer wg.Done()
+        res[i] = doSomething(i,xi)        
     } (i, xi);
 }
 // wait for goroutines to finish
-for i := 0; i < N; ++i { <-sem }
+wg.Wait()
 ```
 
 Notice the use of the anonymous closure.  The current i,xi are passed to the closure as parameters, masking the i,xi variables from the outer for-loop.  This allows each goroutine to have its own copy of i,xi; otherwise, the next iteration of the for-loop would update i,xi in all goroutines. On the other hand, the res array is not passed to the anonymous closure, since each goroutine does not need a separate copy of the array (or slice of the array).  The res array is part of the closure's environment but is not a parameter.
 
-A somewhat practical example, with the semaphore abstracted away:
+A somewhat practical example:
 ```go
-func VectorScalarAdd (v []float, s float) {
-    sem := make (semaphore, len(v));
+func VectorScalarAdd (v []float, s float32) {
+    var wg sync.WaitGroup
     for i,_ := range v {
+        wg.Add(1)
         go func (i int) {
-            v [i] += s;
-            sem.Signal();
-        } (i);
+            defer wg.Done()
+            v [i] += s
+        } (i)
     }
-    sem.Wait(len(v));
+    wg.Wait()
 }
 ```
 ## For-Loops and Futures
@@ -46,8 +48,8 @@ When implementing a function which contains one big parallel for-loop (like the 
 
 It is easy to be overly dependent on channels in Go.  I've seen code like the following in several places:
 ```go
-xi := make(float chan);
-out := make(float chan);
+xi := make(float32 chan);
+out := make(float32 chan);
 // start N goroutines
 for _,_ := range data {
     go func () {
@@ -69,10 +71,10 @@ In addition to being more verbose, it is inefficient because of the extra set-up
 
 ```go
 for _,xi := range data {
-    xch := make(float chan);
+    xch := make(float32 chan)
     go func () {
         xi := <- xch;
-        out <- doSomething(xi);
+        out <- doSomething(xi)
     }
     xch <- xi;
 }


### PR DESCRIPTION
Using https://golang.org/pkg/sync/#example_WaitGroup

Also, removed semicolon in "good" examples as it is more idiomatic to not use them.
`float` does not exists. Replaced with `float32` so the code can be copied.